### PR TITLE
Fix for issue where spawning a npc would change relation of its default group with player

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -38,14 +38,7 @@ function NearPed(model, coords)
     SetEntityInvincible(spawnedPed, true)
     FreezeEntityPosition(spawnedPed, true)
     SetBlockingOfNonTemporaryEvents(spawnedPed, true)
-    -- set relationship group between npc and player
-    SetPedRelationshipGroupHash(spawnedPed, GetPedRelationshipGroupHash(spawnedPed))
-    SetRelationshipBetweenGroups(1, GetPedRelationshipGroupHash(spawnedPed), `PLAYER`)
-    if Config.Debug then
-        local relationship = GetRelationshipBetweenGroups(GetPedRelationshipGroupHash(spawnedPed), `PLAYER`)
-        print(relationship)
-    end
-    -- end of relationship group
+    SetPedCanBeTargetted(spawnedPed, false)
     if Config.FadeIn then
         for i = 0, 255, 51 do
             Wait(50)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-npcs'
-version '1.0.9'
+version '1.0.10'
 
 shared_scripts {
     'config.lua'


### PR DESCRIPTION
Steps to reproduce issue

walk to bank npc and let it spawn
go outside and try to punch people (it would allow only pushing)
Instead of setting ped's default group friendly to player (assuming to prevent player from punching it), we can disable targeting of the ped and not change default ped group relation with player, which has unintended side effects, where we cannot freely attack ambient peds