### PR TITLE
feat(npcs): add optional scenario animations

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -9,7 +9,7 @@ CreateThread(function()
             local distance = #(playerCoords - v.coords.xyz)
 
             if distance < Config.DistanceSpawn and not spawnedPeds[k] then
-                local spawnedPed = NearPed(v.model, v.coords)
+                local spawnedPed = NearPed(v.model, v.coords, v)
                 spawnedPeds[k] = { spawnedPed = spawnedPed }
             end
             
@@ -27,7 +27,7 @@ CreateThread(function()
     end
 end)
 
-function NearPed(model, coords)
+function NearPed(model, coords, pedData)
     RequestModel(model)
     while not HasModelLoaded(model) do
         Wait(50)
@@ -40,14 +40,21 @@ function NearPed(model, coords)
     FreezeEntityPosition(spawnedPed, true)
     SetBlockingOfNonTemporaryEvents(spawnedPed, true)
     SetPedCanBeTargetted(spawnedPed, false)
+    -- ADDED: Start scenario if defined
+    if pedData and pedData.scenario then
+        TaskStartScenarioInPlace(spawnedPed, pedData.scenario, 0, true)
+    end
+    
     if Config.FadeIn then
         for i = 0, 255, 51 do
             Wait(50)
             SetEntityAlpha(spawnedPed, i, false)
         end
     end
+    
     return spawnedPed
 end
+
 
 Citizen.CreateThread(function()
     for k, PedList in pairs(Config.PedList) do

--- a/config.lua
+++ b/config.lua
@@ -152,6 +152,7 @@ Config.PedList = {
         blipName = 'Barber Valentine',
         blipSprite = 'blip_shop_barber',
         blipScale = 0.2,
+        scenario = "WORLD_HUMAN_WRITE_NOTEBOOK" -- Animation here
     },
     {   -- barber Saint Denis
         model = `s_m_m_barber_01`,


### PR DESCRIPTION
This PR introduces lightweight **scenario/animation** support for spawned **NPCs**
• Keeps full backward-compatibility: NPCs without `scenario` behave exactly as before

in config add: 
scenario = "WORLD_HUMAN_BROOM"

_**Testing**_

- Spawn distance, fade-in/out and despawn logic verified unchanged.
- Added a doctor NPC with scenario = "WORLD_HUMAN_WRITE_NOTEBOOK" – animation starts immediately on spawn.
- NPCs without a scenario field spawn idle as before.
- No errors in F8 console after 15 minutes of continuous spawn/despawn cycles.
- Backward compatibility existing servers can merge without touching their current config.lua; scenario support is purely opt-in.